### PR TITLE
数字の上にカーソルがない場合、期待した動作をしない

### DIFF
--- a/plugin/trip.vim
+++ b/plugin/trip.vim
@@ -8,14 +8,14 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-noremap <expr> <Plug>(trip-increment) trip#increment('\S-\d\+', "\<C-x>")
-noremap <expr> <Plug>(trip-decrement) trip#decrement('\S-\d\+', "\<C-a>")
+noremap <expr> <Plug>(trip-increment) trip#increment('.*\S-\d\+', "\<C-x>")
+noremap <expr> <Plug>(trip-decrement) trip#decrement('.*\S-\d\+', "\<C-a>")
 
 
 noremap <expr> <Plug>(trip-increment-ignore-minus)
-\	trip#increment('-\d\+', "\<C-x>")
+\	trip#increment('.*-\d\+', "\<C-x>")
 noremap <expr> <Plug>(trip-decrement-ignore-minus)
-\	trip#decrement('-\d\+', "\<C-a>")
+\	trip#decrement('.*-\d\+', "\<C-a>")
 
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
```
nmap <C-a> <Plug>(trip-increment)
nmap <C-x> <Plug>(trip-decrement)
```

とマッピングしている時、

```
aaaaaa-3
```

のようなテキストの`a`の上にカーソルがある場合に`<C-a>`を押すと`aaaaaa-2`になってしまい、インクリメントとデクリメントが逆転されていなかったので、それを修正しました。
